### PR TITLE
feat: add creation form and database integration

### DIFF
--- a/pastry/app/api/creations/route.ts
+++ b/pastry/app/api/creations/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { db, bucket } from "@/lib/firebase";
+import { randomUUID } from "crypto";
+
+interface CreationData {
+  title: string;
+  difficulty: string;
+  time: string;
+  recipe: string;
+  image: string;
+}
+
+export async function POST(req: Request) {
+  const form = await req.formData();
+  const title = form.get("title")?.toString() || "";
+  const difficulty = form.get("difficulty")?.toString() || "";
+  const time = form.get("time")?.toString() || "";
+  const recipe = form.get("recipe")?.toString() || "";
+  const file = form.get("image") as File | null;
+
+  let image = "";
+  if (file) {
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const filename = `creations/${randomUUID()}-${file.name}`;
+    const storedFile = bucket.file(filename);
+    await storedFile.save(buffer, { contentType: file.type });
+    await storedFile.makePublic();
+    image = `https://storage.googleapis.com/${bucket.name}/${filename}`;
+  }
+
+  const data: CreationData = { title, difficulty, time, recipe, image };
+  const doc = await db.collection("creations").add(data);
+  return NextResponse.json({ id: doc.id });
+}

--- a/pastry/app/creations/[id]/page.tsx
+++ b/pastry/app/creations/[id]/page.tsx
@@ -1,6 +1,12 @@
 import { db } from "@/lib/firebase";
 
-interface Creation { title: string; image: string; description: string }
+interface Creation {
+  title: string;
+  image: string;
+  difficulty: string;
+  time: string;
+  recipe: string;
+}
 
 export default async function CreationDetailPage({ params }: { params: { id: string } }) {
   const snap = await db.collection("creations").doc(params.id).get();
@@ -18,7 +24,9 @@ export default async function CreationDetailPage({ params }: { params: { id: str
     <div className="container">
       <h1 className="title">{creation.title}</h1>
       <img src={creation.image} alt={creation.title} />
-      <p>{creation.description}</p>
+      <p>Difficulty: {creation.difficulty}</p>
+      <p>Time: {creation.time}</p>
+      <p>{creation.recipe}</p>
     </div>
   );
 }

--- a/pastry/app/creations/new/page.tsx
+++ b/pastry/app/creations/new/page.tsx
@@ -1,0 +1,22 @@
+import styles from "../creations.module.scss";
+
+export default function NewCreationPage() {
+  return (
+    <div className={`container ${styles.wrapper}`}>
+      <h1 className="title">New Creation</h1>
+      <form
+        action="/api/creations"
+        method="POST"
+        encType="multipart/form-data"
+        className={styles.grid}
+      >
+        <input type="text" name="title" placeholder="Title" required />
+        <input type="text" name="difficulty" placeholder="Difficulty" required />
+        <input type="text" name="time" placeholder="Time" required />
+        <textarea name="recipe" placeholder="Recipe" required />
+        <input type="file" name="image" accept="image/*" required />
+        <button type="submit">Create</button>
+      </form>
+    </div>
+  );
+}

--- a/pastry/app/creations/page.tsx
+++ b/pastry/app/creations/page.tsx
@@ -1,21 +1,30 @@
 import ProductCard from "@/components/productcard/ProductCard";
 import styles from "./creations.module.scss";
+import { db } from "@/lib/firebase";
 
-const CREATIONS = [
-  { title: "Citrus Crown", image: "/images/creation-1.jpg", description: "Layered citrus confit, soft mousse, crunchy base." },
-  { title: "Hazelnut Prism", image: "/images/creation-2.jpg", description: "Praliné heart, gianduja veil, almond dacquoise." },
-  { title: "Raspberry Orb", image: "/images/creation-3.jpg", description: "Raspberry compote, vanilla cream, sable breton." },
-  { title: "Chocolate Monolith", image: "/images/creation-4.jpg", description: "70% grand cru chocolate, cocoa nib crunch, caramel core." },
-];
+interface Creation {
+  id: string;
+  title: string;
+  image: string;
+  difficulty: string;
+  time: string;
+  recipe: string;
+}
 
-export default function CreationsPage() {
+export default async function CreationsPage() {
+  const snap = await db.collection("creations").get();
+  const creations: Creation[] = snap.docs.map((d) => ({
+    id: d.id,
+    ...(d.data() as Omit<Creation, "id">),
+  }));
+
   return (
     <div className={`container ${styles.wrapper}`}>
       <h1 className="title">Creations</h1>
       <p className="muted">Seasonal pastries and signature pieces.</p>
       <div className={styles.grid}>
-        {CREATIONS.map((c) => (
-          <ProductCard key={c.title} {...c} />
+        {creations.map((c) => (
+          <ProductCard key={c.id} {...c} />
         ))}
       </div>
     </div>

--- a/pastry/components/productcard/ProductCard.tsx
+++ b/pastry/components/productcard/ProductCard.tsx
@@ -1,9 +1,16 @@
 import Link from "next/link";
 import styles from "./ProductCard.module.scss";
 
-type Props = { id: string; title: string; image: string; description?: string };
+type Props = {
+  id: string;
+  title: string;
+  image: string;
+  difficulty: string;
+  time: string;
+  recipe: string;
+};
 
-export default function ProductCard({ id, title, image, description }: Props) {
+export default function ProductCard({ id, title, image, difficulty, time, recipe }: Props) {
   return (
     <Link href={`/creations/${id}`} className={styles.card}>
       <div className={styles.thumbWrap}>
@@ -11,7 +18,9 @@ export default function ProductCard({ id, title, image, description }: Props) {
       </div>
       <div className={styles.meta}>
         <h3>{title}</h3>
-        {description && <p>{description}</p>}
+        <p>Difficulty: {difficulty}</p>
+        <p>Time: {time}</p>
+        <p>{recipe}</p>
       </div>
     </Link>
   );

--- a/pastry/lib/firebase.ts
+++ b/pastry/lib/firebase.ts
@@ -1,6 +1,7 @@
 import { cert, getApps, initializeApp } from "firebase-admin/app";
 import { ServiceAccount } from "firebase-admin";
 import { getFirestore } from "firebase-admin/firestore";
+import { getStorage } from "firebase-admin/storage";
 
 const serviceAccount: ServiceAccount = {
   projectId: process.env.project_id,
@@ -10,6 +11,10 @@ const serviceAccount: ServiceAccount = {
 
 const app = getApps().length
   ? getApps()[0]
-  : initializeApp({ credential: cert(serviceAccount) });
+  : initializeApp({
+      credential: cert(serviceAccount),
+      storageBucket: process.env.storage_bucket,
+    });
 
 export const db = getFirestore(app);
+export const bucket = getStorage(app).bucket();


### PR DESCRIPTION
## Summary
- fetch creations from Firestore
- add form and API route to create creations with image upload
- show difficulty, time and recipe on creation cards and detail page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b84fd97cc8331af5e8c7fa679dd30